### PR TITLE
fix(table): add table-wrap for mobile horizontal scroll

### DIFF
--- a/projects/2605101/doc-viewer/design-standards/base-html-rules.md
+++ b/projects/2605101/doc-viewer/design-standards/base-html-rules.md
@@ -212,6 +212,33 @@ font-family: "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", "SimSun", Ari
 
 ---
 
+## 12. 表格移动端适配（必须）
+
+所有使用原生 `<table>` 的模板，必须用 `.table-wrap` 包裹：
+
+```html
+<div class="table-wrap">
+  <table>...</table>
+</div>
+```
+
+对应 CSS 规则：
+
+```css
+.table-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin: 12px 0 18px;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+```
+
+**注意：** CSS Grid / Flexbox 布局的页面（div 结构）不需要此规则，只有 `<table>` 才需要。
+
+
 ## 11. Do's and Don'ts
 
 **Do's：**
@@ -220,6 +247,7 @@ font-family: "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", "SimSun", Ari
 - ✅ 响应式断点至少覆盖 480px / 768px / 1024px
 - ✅ 字体栈以中文字体优先
 - ✅ 设置 `:root` CSS 变量定义风格颜色
+- ✅ 所有 `<table>` 必须包裹 `.table-wrap`（适用于含 table 的 skeleton）
 
 **Don'ts：**
 - ❌ 在 HTML 中直接写颜色值
@@ -227,3 +255,4 @@ font-family: "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", "SimSun", Ari
 - ❌ 硬编码宽度（如 `width: 1200px`），使用 `max-width` + `100%`
 - ❌ 省略 viewport meta 标签
 - ❌ 使用 JS 动画框架
+- ❌ `<table>` 未包裹 `.table-wrap`（移动端表格会溢出）

--- a/projects/2605101/doc-viewer/templates/style-06/skeleton.html
+++ b/projects/2605101/doc-viewer/templates/style-06/skeleton.html
@@ -124,6 +124,13 @@ a { color:#D98B52; text-decoration:none; }
   font-size:11pt; color:#9CA3AF; border-top:1px solid #E5E7EB;
   text-align:center;
 }
+
+/* ===== TABLE WRAP (mobile scroll) ===== */
+.table-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin: 12px 0 18px;
+}
 </style>
 </head>
 <body>
@@ -175,7 +182,7 @@ a { color:#D98B52; text-decoration:none; }
   <div class="specs">
     <div class="section-label">产品信息</div>
     <div class="section-title">基本规格</div>
-    <table class="specs-table">
+    <div class="table-wrap"><table class="specs-table">
       <tr><th>化合物名</th><td>CG-0255 (Evategrel / 依福格雷)</td></tr>
       <tr><th>靶点</th><td>P2Y12受体</td></tr>
       <tr><th>分子式</th><td>C₂₁H₂₆ClNO₇S</td></tr>


### PR DESCRIPTION
## 问题

生成的投资报告页面在手机端表格超出屏幕宽度，无法完整显示，必须左右滑动。

根因：生成文件时跳过了 table-spec.md 中的 .table-wrap 包裹步骤。

## 修复内容

- **base-html-rules.md**: 新增第12节「表格移动端适配」，强制要求所有 table 必须包裹 .table-wrap；同步更新 DOs and DONTs。
- **style-06 skeleton.html**: 添加 .table-wrap CSS 规则，并将 table 用 div.table-wrap 包裹。

## 测试

修复后生成 style-01~11 共11个页面，表格在手机端可左右滑动查看，PC端不受影响。